### PR TITLE
add pk reset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,13 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.15.0)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -220,6 +224,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Review the Active Record code/results below.  It appears to be working to reset all tables PK.

irb(main):001:1* ActiveRecord::Base.connection.tables.each do |t|
irb(main):002:1*   ActiveRecord::Base.connection.reset_pk_sequence!(t)
irb(main):003:0> end
=> ["schema_migrations", "ar_internal_metadata", "customers", "merchants", "items", "invoice_items", "invoices", "transactions"]