### PR TITLE
Fix Item Create

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,10 +13,10 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @merchant = Merchant.find(params[:merchant_id])
-    item = Item.create(item_params)
-    item.save
-    redirect_to "/merchants/#{@merchant.id}/items"
+    merchant = Merchant.find(params[:merchant_id])
+    item = merchant.items.create(item_params)
+
+    redirect_to "/merchants/#{merchant.id}/items"
   end
 
   def edit


### PR DESCRIPTION
The create method in the item controller wasn't associated with a merchant so it wasn't displaying properly on the page after being created. PR fixes this issue.